### PR TITLE
Add VS Code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ text on unchanged.
 $ stack install
 ```
 
+### Emacs
+
 From within Emacs, assuming you have the `haskell-mode` and
 `stylish-haskell` packages installed and working, `(setq
 haskell-mode-stylish-haskell-path "simformat")` and `(setq
@@ -35,5 +37,23 @@ If you prefer not to run code on save, you can use
 `shell-command-on-region` with a region active and the prefix argument
 set, i.e. `C-u M-| simformat`
 
+### Vim
+
 From within Vim, e.g., visual select your code (or the whole file) and
 then run `:!simformat`
+
+### Visual Studio Code
+
+After installing the `simformat` executable using `stack`, link the `simformat-file` wrapper to somewhere on your path.
+
+For example:
+
+```
+ln -s ~/dev/simspace/simformat/simformat-file ~/.local/bin/simformat-file
+```
+
+(Make sure to use absolute paths when using `ln`.)
+
+Then in your project directory, create a `.vscode/tasks.json` file and add the contents of the `vscode-tasks.json` file checked in this repo.
+
+Finally, with a Haskell file open in VS Code, hit `Shift+Cmd+B`, and select `simformat` from the build task list. It will format the opened file in-place.

--- a/simformat-file
+++ b/simformat-file
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eu
+
+contents=$(<$1)
+echo "$contents" | simformat > $1

--- a/vscode-tasks.json
+++ b/vscode-tasks.json
@@ -1,0 +1,18 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "simformat",
+      "group": "build",
+      "type": "shell",
+      "command": "simformat-file",
+      "args": [
+        "${file}"
+      ],
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "silent"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Add a `simformat-file` wrapper that takes a file path and formats in place (could probably have modified the Haskell executable, but wanted something quick). VS Code tasks can take the path to a file as input, but don't seem to work with stdin/stdout.
- Update instructions for VS Code