### PR TITLE
[NO TICKET] `-r,--regroup-imports`

### DIFF
--- a/app/main.hs
+++ b/app/main.hs
@@ -23,7 +23,14 @@ data Operation
   | StdIO
 
 parseOperation :: Parser Operation
-parseOperation = printVersion <|> printNumericVersion <|> inPlace <|> allDirty <|> stdIO
+parseOperation =
+    (
+      printVersion
+      <|> printNumericVersion
+      <|> inPlace
+      <|> allDirty
+      <|> stdIO
+    )
   where
     printVersion = flag' PrintVersion
       $  long "version"

--- a/app/main.hs
+++ b/app/main.hs
@@ -4,7 +4,10 @@ import Control.Applicative ((<|>))
 import Data.Foldable (traverse_)
 import Data.Semigroup ((<>))
 import Data.Version (showVersion)
-import Options.Applicative (Parser, execParser, flag', fullDesc, help, helper, info, long, metavar, progDesc, short, strOption)
+import Options.Applicative
+  ( Parser, execParser, flag', fullDesc, help, helper, info, long, metavar, progDesc, short
+  , strOption, switch
+  )
 import Turtle (decodeString, inshell, liftIO, lineToText, testfile)
 import Turtle.Shell (FoldShell(FoldShell), foldShell)
 import qualified Data.ByteString as BS
@@ -16,11 +19,11 @@ import SimSpace.SimFormat (reformat)
 import qualified Paths_simformat as Paths
 
 data Operation
-  = PrintVersion
-  | PrintNumericVersion
-  | InPlace FilePath
-  | AllDirty
-  | StdIO
+  = PrintVersion Bool
+  | PrintNumericVersion Bool
+  | InPlace FilePath Bool
+  | AllDirty Bool
+  | StdIO Bool
 
 parseOperation :: Parser Operation
 parseOperation =
@@ -31,6 +34,7 @@ parseOperation =
       <|> allDirty
       <|> stdIO
     )
+    <*> regroup
   where
     printVersion = flag' PrintVersion
       $  long "version"
@@ -49,24 +53,42 @@ parseOperation =
       <> help "operate on all dirty files in-place instead of reading from stdin and writing to stdout"
     stdIO = pure StdIO
 
+    regroup =
+      switch
+        (
+          long "regroup-imports"
+          <> short 'r'
+          <> help (
+               "Try to be smart and re-group imports into a prelude "
+               <> "group, a non-local group, and a local group, where "
+               <> "\"local\" means things that are being built out of "
+               <> "your stack.yaml file. This is really, really slow, "
+               <> "and the slowness is linear with the number of import "
+               <> "statements you have because it uses `ghc-pkg` to figure "
+               <> "out where packages come from. It also requires that "
+               <> "you are using stack."
+             )
+        )
+     <|> pure False
+
 main :: IO ()
 main = execParser opts >>= \case
-    PrintVersion        -> putStrLn $ "simformat " ++ showVersion Paths.version
-    PrintNumericVersion -> putStrLn $ showVersion Paths.version
-    InPlace file        -> oneInPlace file
-    AllDirty            ->
+    PrintVersion _        -> putStrLn $ "simformat " ++ showVersion Paths.version
+    PrintNumericVersion _ -> putStrLn $ showVersion Paths.version
+    InPlace file regroup  -> oneInPlace file regroup
+    AllDirty regroup      ->
       let cmd = inshell "git status --porcelain | grep ^\\.\\*\\.hs$ | sed s/^...//" mempty -- get all the dirty Haskell files in the tree
-          op = FoldShell (\ () file -> () <$ oneInPlace (T.unpack $ lineToText file)) () (const $ pure ()) -- for each file in the shell modify in place
+          op = FoldShell (\ () file -> () <$ oneInPlace (T.unpack $ lineToText file) regroup) () (const $ pure ()) -- for each file in the shell modify in place
       in foldShell cmd op
-    StdIO               -> traverse_ putStrLn =<< reformat . lines <$> getContents
+    StdIO regroup         -> traverse_ putStrLn =<< reformat regroup . lines =<< getContents
   where
-    oneInPlace file = do
+    oneInPlace file regroup = do
       liftIO (testfile $ decodeString file) >>= \ case
         False -> putStrLn $ "Skipping " <> file
         True -> do
           putStrLn $ "Reformatting " <> file
-          BS.writeFile file
-            =<< T.encodeUtf8 . T.pack . unlines . reformat . lines . T.unpack . T.decodeUtf8
-            <$> BS.readFile file
+          BS.writeFile file . T.encodeUtf8 . T.pack . unlines
+            =<< reformat regroup . lines . T.unpack . T.decodeUtf8
+            =<< BS.readFile file
     opts = info (helper <*> parseOperation)
          $ fullDesc <> progDesc "Format the imports of a Haskell file(s)"

--- a/package.yaml
+++ b/package.yaml
@@ -18,6 +18,7 @@ dependencies:
 - containers
 - megaparsec >= 6.0.0
 - optparse-applicative
+- process
 - text
 - turtle
 

--- a/package.yaml
+++ b/package.yaml
@@ -14,10 +14,10 @@ default-extensions:
 
 dependencies:
 - base
+- bytestring
 - containers
 - megaparsec >= 6.0.0
 - optparse-applicative
-- bytestring
 - text
 - turtle
 

--- a/src/SimSpace/SimFormat.hs
+++ b/src/SimSpace/SimFormat.hs
@@ -1,8 +1,14 @@
 {-# OPTIONS -Wno-unused-matches -Wno-unused-local-binds -Wno-unused-top-binds -Wno-unused-imports #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ViewPatterns #-}
+
 module SimSpace.SimFormat (reformat) where
 
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Bool (bool)
 import Data.Char (isSpace)
+import Data.Foldable (foldlM)
 import Data.List (intercalate, isPrefixOf)
 import Data.Map (Map)
 import Data.Maybe (isJust)
@@ -11,11 +17,14 @@ import Data.Set (Set)
 import Data.Void (Void)
 import Debug.Trace
 import System.Environment (getArgs)
+import System.Exit (ExitCode(ExitFailure, ExitSuccess))
+import System.Process (readProcessWithExitCode)
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import Text.Printf (printf)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import qualified Data.Text as Text
 
 type Parser = Parsec Void String
 
@@ -27,6 +36,7 @@ type Parser = Parsec Void String
 newtype SortedImportStmts = SortedImportStmts
   { unSortedImportStmts :: Map (Maybe String, Bool, String, Maybe String) SortedImportList
   }
+  deriving newtype (Semigroup)
   deriving Show
 
 -- High level elements
@@ -347,13 +357,14 @@ type Block = Either BlankLine String
 type Line = String
 
 reformat
-  :: [Line]
+  :: (MonadIO m)
+  => Bool {- ^ Whether to re-group imports. -}
   -> [Line]
-reformat programLines =
+  -> m [Line]
+reformat regroup programLines = do
   let
     (nonimports, importsAndAfter) = break ("import " `isPrefixOf`) programLines
-  in
-    concatMap blockToLines . reassemble nonimports $ untilNothing processBlock (chunkedInputs importsAndAfter)
+  concatMap blockToLines <$> reassemble nonimports (untilNothing processBlock (chunkedInputs importsAndAfter))
 
   where
     blockToLines :: Block -> [String]
@@ -373,13 +384,84 @@ reformat programLines =
     processBlock (Right s) = Right <$> parseMaybe parseImportBlock s
 
     reassemble
-      :: [String]
+      :: (MonadIO m)
+      => [String]
       -> ([Either BlankLine SortedImportStmts], [Block])
-      -> [Block]
-    reassemble nonImports (chunkedImports, leftovers)
-      = fmap Left nonImports
-     <> (fmap.fmap) renderImportStmts chunkedImports
-     <> leftovers
+      -> m [Block]
+    reassemble nonImports (chunkedImports, leftovers) = do
+        rechucked <- (if regroup then rechunk else pure) chunkedImports
+        pure $
+          fmap Left nonImports
+          <> (fmap . fmap) renderImportStmts rechucked
+          <> leftovers
+      where
+        rechunk
+          :: (MonadIO m)
+          => [Either BlankLine SortedImportStmts]
+          -> m [Either BlankLine SortedImportStmts]
+        rechunk ci = do
+          x@(preludes, locals, others) <-
+            foldlM
+              insertCatagorized
+              ([], [], [])
+              (foldMap fromSortedImportStmts [ stmts | Right stmts <- ci ])
+          pure $
+            [
+              Right $ toSortedImportStmts preludes,
+              Left "",
+              Right $ toSortedImportStmts others,
+              Left "",
+              Right $ toSortedImportStmts locals,
+              Left ""
+            ]
+
+        insertCatagorized
+          :: (MonadIO m)
+          => ([ImportStmt], [ImportStmt], [ImportStmt])
+          -> ImportStmt
+          -> m ([ImportStmt], [ImportStmt], [ImportStmt])
+        insertCatagorized (preludes, locals, others) stmt =
+          categorize stmt >>= \case
+            Prelude -> pure (preludes <> [stmt], locals, others)
+            Local -> pure (preludes, locals <> [stmt], others)
+            Other -> pure (preludes, locals, others <> [stmt])
+        
+        categorize :: (MonadIO m) => ImportStmt -> m ImportCategory
+        categorize stmt
+          | importStmtModuleName stmt `contains` "Prelude" =
+              pure Prelude
+          | otherwise =
+              liftIO (
+                readProcessWithExitCode
+                  "bash"
+                  [
+                    "-c",
+                    "stack exec ghc-pkg -- find-module "
+                    <> importStmtModuleName stmt
+                    <> " | grep -v 'pkgdb$' | grep -v 'package.conf.d$' | grep -qv '(no packages)'"
+                  ]
+                  ""
+              ) >>= \case
+                (ExitSuccess, _, _) ->
+                  {- The grep statement found a package.  -}
+                  pure Other
+                (ExitFailure 1, _, _) ->
+                  {-
+                    grep exited with a exit code 1, meaning no packages were
+                    found, meaning this is an internal module.
+                  -}
+                  pure Local
+                procFailed -> fail (show procFailed)
+
+        contains :: String -> String -> Bool
+        contains (Text.pack -> haystack) (Text.pack -> needle) =
+          fst (Text.breakOn needle haystack) /= haystack
+
+
+data ImportCategory
+  = Prelude
+  | Local
+  | Other
 
 -- |divide the input into blocks while preserving the number of separators
 splitOn :: (a -> Either separator b) -> [a] -> [Either separator [b]]

--- a/src/SimSpace/SimFormat.hs
+++ b/src/SimSpace/SimFormat.hs
@@ -389,10 +389,10 @@ reformat regroup programLines = do
       -> ([Either BlankLine SortedImportStmts], [Block])
       -> m [Block]
     reassemble nonImports (chunkedImports, leftovers) = do
-        rechucked <- (if regroup then rechunk else pure) chunkedImports
+        rechunked <- (if regroup then rechunk else pure) chunkedImports
         pure $
           fmap Left nonImports
-          <> (fmap . fmap) renderImportStmts rechucked
+          <> (fmap . fmap) renderImportStmts rechunked
           <> leftovers
       where
         rechunk

--- a/src/SimSpace/SimFormat.hs
+++ b/src/SimSpace/SimFormat.hs
@@ -346,7 +346,9 @@ type BlankLine = String
 type Block = Either BlankLine String
 type Line = String
 
-reformat :: [Line] -> [Line]
+reformat
+  :: [Line]
+  -> [Line]
 reformat programLines =
   let
     (nonimports, importsAndAfter) = break ("import " `isPrefixOf`) programLines
@@ -370,9 +372,10 @@ reformat programLines =
     processBlock (Left  s) = pure (Left s)
     processBlock (Right s) = Right <$> parseMaybe parseImportBlock s
 
-    reassemble :: [String]
-               -> ([Either BlankLine SortedImportStmts], [Block])
-               -> [Block]
+    reassemble
+      :: [String]
+      -> ([Either BlankLine SortedImportStmts], [Block])
+      -> [Block]
     reassemble nonImports (chunkedImports, leftovers)
       = fmap Left nonImports
      <> (fmap.fmap) renderImportStmts chunkedImports

--- a/src/SimSpace/SimFormat.hs
+++ b/src/SimSpace/SimFormat.hs
@@ -9,7 +9,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Bool (bool)
 import Data.Char (isSpace)
 import Data.Foldable (foldlM)
-import Data.List (intercalate, isPrefixOf)
+import Data.List (intercalate, isInfixOf, isPrefixOf)
 import Data.Map (Map)
 import Data.Maybe (isJust)
 import Data.Semigroup ((<>), Semigroup)
@@ -24,7 +24,6 @@ import Text.Megaparsec.Char
 import Text.Printf (printf)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import qualified Data.Text as Text
 
 type Parser = Parsec Void String
 
@@ -428,7 +427,7 @@ reformat regroup programLines = do
         
         categorize :: (MonadIO m) => ImportStmt -> m ImportCategory
         categorize stmt
-          | importStmtModuleName stmt `contains` "Prelude" =
+          | "Prelude" `isInfixOf` importStmtModuleName stmt =
               pure Prelude
           | otherwise =
               liftIO (
@@ -452,10 +451,6 @@ reformat regroup programLines = do
                   -}
                   pure Local
                 procFailed -> fail (show procFailed)
-
-        contains :: String -> String -> Bool
-        contains (Text.pack -> haystack) (Text.pack -> needle) =
-          fst (Text.breakOn needle haystack) /= haystack
 
 
 data ImportCategory


### PR DESCRIPTION
Added an option to re-group imports.

Picking reviewers based on the recent git history and also some people I know care about this sort of thing.

```
  -r,--regroup-imports     Try to be smart and re-group imports into a prelude
                           group, a non-local group, and a local group, where
                           "local" means things that are being built out of your
                           stack.yaml file. This is really, really slow, and the
                           slowness is linear with the number of import
                           statements you have because it uses `ghc-pkg` to
                           figure out where packages come from. It also requires
                           that you are using stack.
```

