### PR TITLE
Parse trailing commas in imports

### DIFF
--- a/src/SimSpace/SimFormat.hs
+++ b/src/SimSpace/SimFormat.hs
@@ -103,7 +103,7 @@ padded :: Parser a -> Parser a
 padded = between space space
 
 commaSep :: Parser a -> Parser [a]
-commaSep a = sepBy (padded a) (padded comma)
+commaSep a = sepEndBy (padded a) (padded comma)
 
 parens :: Parser a -> Parser a
 parens = between (ptoken "(") (ptoken ")")


### PR DESCRIPTION
Replace a usage of `sepBy` with `sepEndBy` so simformat doesn't choke on trailing commas in imports.