### PR TITLE
Add a whitelist

### DIFF
--- a/app/simformat.hs
+++ b/app/simformat.hs
@@ -9,7 +9,7 @@ import Data.Maybe (catMaybes)
 import Data.Traversable (for)
 import Data.Version (showVersion)
 import Data.Yaml (decodeFileEither)
-import SimSpace.Config (Config(Config), configFiles, emptyConfig, filterFiles)
+import SimSpace.Config (Config(Config), configFiles, configWhitelist, emptyConfig, filterFiles)
 import Turtle (decodeString, liftIO, testfile)
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
@@ -106,7 +106,7 @@ main = do
     format verbose Config {..} fileMay regroup validate = do
       files <- case fileMay of
         Just file -> pure [file]
-        Nothing -> filterFiles configFiles
+        Nothing -> filterFiles configFiles configWhitelist
       inputsAndOutputs <- fmap catMaybes . for files $ \ file ->
         liftIO (testfile $ decodeString file) >>= \ case
           False -> do

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: simformat
-version: 0.1.0.0
+version: 0.1.1.0
 
 ghc-options:
 - -Wall

--- a/src/SimSpace/Config.hs
+++ b/src/SimSpace/Config.hs
@@ -11,7 +11,7 @@ module SimSpace.Config (
 
 import Control.Monad ((>=>))
 import Data.List (isPrefixOf, isSuffixOf)
-import Data.Yaml ((.:), FromJSON, parseJSON, withObject)
+import Data.Yaml ((.!=), (.:?), FromJSON, parseJSON, withObject)
 import System.Directory (makeAbsolute, makeRelativeToCurrentDirectory)
 import System.Process (readCreateProcess, shell)
 
@@ -59,5 +59,5 @@ emptyConfig = Config
 instance FromJSON Config where
   parseJSON = withObject "Config" $ \obj ->
     Config
-      <$> obj .: "files"
-      <*> obj .: "whitelist"
+      <$> obj .:? "files" .!= configFiles emptyConfig
+      <*> obj .:? "whitelist" .!= configWhitelist emptyConfig


### PR DESCRIPTION
This is so that I can include one directory but not another directory inside of it that includes generated files.

An example config:

```yaml
files:
  - foo
whitelist:
  - foo/bar
```