### PR TITLE
Support directory with the -i option

### DIFF
--- a/app/simformat.hs
+++ b/app/simformat.hs
@@ -9,7 +9,7 @@ import Data.Maybe (catMaybes)
 import Data.Traversable (for)
 import Data.Version (showVersion)
 import Data.Yaml (decodeFileEither)
-import SimSpace.Config (Config(Config), configFiles, configWhitelist, emptyConfig, filterFiles)
+import SimSpace.Config (Config(Config), FormatFiles(FormatFiles), configFiles, configWhitelist, emptyConfig, filterFiles)
 import Turtle (decodeString, liftIO, testfile)
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
@@ -64,7 +64,7 @@ parseOperation =
       $  Opt.long "in-place"
       <> Opt.short 'i'
       <> Opt.metavar "TARGET"
-      <> Opt.help "operate on a file in-place instead of reading from stdin and writing to stdout"
+      <> Opt.help "operate on a file (or all the haskell files in a directory) in-place instead of reading from stdin and writing to stdout"
     repo = pure Repo
     editor = Opt.flag' Editor
       $  Opt.long "editor"
@@ -112,7 +112,7 @@ main = do
   where
     format verbose Config {..} fileMay regroup validate = do
       files <- case fileMay of
-        Just file -> pure [file]
+        Just file -> filterFiles (FormatFiles [file]) configWhitelist
         Nothing -> filterFiles configFiles configWhitelist
       inputsAndOutputs <- fmap catMaybes . for files $ \ file ->
         liftIO (testfile $ decodeString file) >>= \ case


### PR DESCRIPTION
Useful for formatting whole directories that are not included in the `.simformatrc` file. 
Uses the same code path as paths in the config file so only Haskell files that are not whitelisted are included.

Example usage: 
```
> sformat -i hardhat-server --versbose
Reformatting hardhat-server/app/docs.hs
Reformatting hardhat-server/app/main.hs
Reformatting hardhat-server/benchmarks/bench.hs
Reformatting hardhat-server/src/Hardhat/Api.hs
Reformatting hardhat-server/src/Hardhat/Auth.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher/ContentRepo.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher/ContentRepo/Entry.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher/ContentRepoUtils.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher/Entity.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher/LocalSpecEntity.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher/OperatingSystem.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher/Org.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher/Project.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher/PuppetConfiguration.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher/SessionSpec.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher/Specification.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher/SpecificationYaml.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher/VersionedEntity.hs
Reformatting hardhat-server/src/Hardhat/Dispatcher/Wizard.hs
Reformatting hardhat-server/src/Hardhat/ExternalEntityPredicate.hs
Reformatting hardhat-server/src/Hardhat/Geppetto/Csv.hs
Reformatting hardhat-server/src/Hardhat/Geppetto/Rest.hs
Reformatting hardhat-server/src/Hardhat/ReferenceValidation.hs
Reformatting hardhat-server/src/Hardhat/Servant/Api2.hs
Reformatting hardhat-server/src/Hardhat/Servant/MonadAppReader.hs
Reformatting hardhat-server/src/Hardhat/Servant/MonadHttpFail.hs
Reformatting hardhat-server/src/Hardhat/Servant/Server.hs
Reformatting hardhat-server/src/Hardhat/SpecValidation.hs
Reformatting hardhat-server/src/Hardhat/Utils.hs
Reformatting hardhat-server/src/Hardhat/WebSocket.hs
Reformatting hardhat-server/src/Hardhat/Wizard.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Config.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Config/Types.hs
Reformatting hardhat-server/src/Hardhat/Wizard/ConfigSpec.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Conversion.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Conversion/TrafficConfig.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Conversion/TrafficConfig/TH.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Conversion/Types.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Merge.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Summary.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Summary/Types.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Types.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Validation.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Validation/Framework.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Validation/Framework/Types.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Validation/ListCidrFields.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Validation/ListSubnetFields.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Validation/ListVmCounts.hs
Reformatting hardhat-server/src/Hardhat/Wizard/Validation/Types.hs
Reformatting hardhat-server/src/Hardhat/Yesod/Application.hs
Reformatting hardhat-server/src/Hardhat/Yesod/Application/EvictUnsaved.hs
Reformatting hardhat-server/src/Hardhat/Yesod/Foundation.hs
Reformatting hardhat-server/src/Hardhat/Yesod/Settings.hs
Reformatting hardhat-server/tests/HardhatTestUtils.hs
Reformatting hardhat-server/tests/Main.hs
Reformatting hardhat-server/tests/Test/Expansion.hs
Reformatting hardhat-server/tests/Test/Geppetto/CsvSpec.hs
Reformatting hardhat-server/tests/Test/SpecValidation.hs
Reformatting hardhat-server/tests/Test/SpecValidation/Flatten.hs
Reformatting hardhat-server/tests/Test/SpecValidation/SupportedNics.hs
Reformatting hardhat-server/tests/Test/SpecValidation/TrafficConfig.hs
Reformatting hardhat-server/tests/Test/Turchini.hs
Reformatting hardhat-server/tests/Test/Utils.hs
Reformatting hardhat-server/tests/Test/Values.hs
Reformatting hardhat-server/tests/Test/VersionedSpec/ImportExport.hs
Reformatting hardhat-server/tests/Test/Wizard.hs
Reformatting hardhat-server/utils/migrateSpec/migrateSpec.hs
```