### PR TITLE
Change the default behavior to take arguments, and filter them by what's opted in

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -17,6 +17,8 @@ default-extensions:
 - LambdaCase
 - RecordWildCards
 - OverloadedStrings
+- ScopedTypeVariables
+- TupleSections
 
 dependencies:
 - base

--- a/package.yaml
+++ b/package.yaml
@@ -44,6 +44,16 @@ executables:
     - simformat
 
 tests:
+  test:
+    main: main.hs
+    source-dirs: test
+    dependencies:
+      - simformat
+
+      - hspec
+      - QuickCheck
+      - unliftio
+
   simformat-doctests:
     main: doctests.hs
     dependencies:

--- a/simformat.cabal
+++ b/simformat.cabal
@@ -1,8 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
+--
+-- hash: 881fa41dfe20fc93f2b8ba09c9e7a3c5c486f1f670bb4b6648afc3da99a73d31
 
 name:           simformat
 version:        0.1.1.0
@@ -27,7 +29,7 @@ library
       Paths_simformat
   hs-source-dirs:
       src
-  default-extensions: LambdaCase RecordWildCards OverloadedStrings
+  default-extensions: LambdaCase RecordWildCards OverloadedStrings ScopedTypeVariables TupleSections
   ghc-options: -Wall -Werror -fwarn-tabs -O2
   build-depends:
       base
@@ -49,7 +51,7 @@ executable simformat
       Paths_simformat
   hs-source-dirs:
       app
-  default-extensions: LambdaCase RecordWildCards OverloadedStrings
+  default-extensions: LambdaCase RecordWildCards OverloadedStrings ScopedTypeVariables TupleSections
   ghc-options: -Wall -Werror -fwarn-tabs -O2
   build-depends:
       base
@@ -71,7 +73,7 @@ test-suite simformat-doctests
   main-is: doctests.hs
   other-modules:
       Paths_simformat
-  default-extensions: LambdaCase RecordWildCards OverloadedStrings
+  default-extensions: LambdaCase RecordWildCards OverloadedStrings ScopedTypeVariables TupleSections
   ghc-options: -Wall -Werror -fwarn-tabs -O2
   build-depends:
       base

--- a/simformat.cabal
+++ b/simformat.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 881fa41dfe20fc93f2b8ba09c9e7a3c5c486f1f670bb4b6648afc3da99a73d31
+-- hash: 5c46bb332a1294b169b2b308b8ea60592fc4a23468f74be41f62016e1a1d34d7
 
 name:           simformat
 version:        0.1.1.0
@@ -87,5 +87,33 @@ test-suite simformat-doctests
     , process
     , text
     , turtle
+    , yaml
+  default-language: Haskell2010
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: main.hs
+  other-modules:
+      ConfigSpec
+      Paths_simformat
+  hs-source-dirs:
+      test
+  default-extensions: LambdaCase RecordWildCards OverloadedStrings ScopedTypeVariables TupleSections
+  ghc-options: -Wall -Werror -fwarn-tabs -O2
+  build-depends:
+      QuickCheck
+    , base
+    , bytestring
+    , containers
+    , directory
+    , filepath
+    , hspec
+    , megaparsec >=6.0.0
+    , optparse-applicative
+    , process
+    , simformat
+    , text
+    , turtle
+    , unliftio
     , yaml
   default-language: Haskell2010

--- a/src/SimSpace/Config.hs
+++ b/src/SimSpace/Config.hs
@@ -5,7 +5,7 @@
 {- | Description: Configuration for formatting program. -}
 module SimSpace.Config (
   Config(..), emptyConfig,
-  FormatFiles(..), filterFiles,
+  FormatFiles(..), WhitelistFiles(..), filterFiles,
 ) where
 
 

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -1,0 +1,51 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module ConfigSpec where
+
+import Data.List (intercalate)
+import Data.Yaml (encode)
+import System.FilePath ((</>))
+import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck (Arbitrary, Gen, arbitrary, elements, generate, listOf1)
+import UnliftIO.Temporary (withSystemTempDirectory)
+import qualified Data.ByteString.Char8 as C8
+
+-- the module being tested
+import SimSpace.Config
+
+newtype AbsoluteTest = AbsoluteTest { unAbsoluteTest :: FilePath }
+  deriving (Eq, Show)
+
+newtype RelativeTest = RelativeTest { unRelativeTest :: FilePath }
+  deriving (Eq, Show)
+
+alphaWord :: Gen FilePath
+alphaWord = listOf1 $ elements ['a'..'z']
+
+instance Arbitrary AbsoluteTest where
+  arbitrary = AbsoluteTest . ("/" <>) . intercalate "/" <$> listOf1 alphaWord
+
+instance Arbitrary RelativeTest where
+  arbitrary = RelativeTest . intercalate "/" <$> listOf1 alphaWord
+
+instance Arbitrary Config where
+  arbitrary = Config
+    <$> (FormatFiles . fmap unRelativeTest <$> listOf1 arbitrary)
+    <*> (WhitelistFiles . fmap unRelativeTest <$> listOf1 arbitrary)
+
+spec :: Spec
+spec = describe "Config" $ do
+  prop "absolute filename is always valid" $ \ (AbsoluteTest fp) -> isValid [fp] [] (fp </> "test.hs") `shouldBe` True
+  prop "relative filename is always valid" $ \ (RelativeTest fp) -> isValid [fp] [] (fp </> "test.hs") `shouldBe` True
+  prop "filtered absolute directory is not valid" $ \ (AbsoluteTest fp) -> isValid [fp] [fp </> "bar"] (fp </> "bar" </> "bin") `shouldBe` False
+  prop "filtered relative directory is not valid" $ \ (RelativeTest fp) -> isValid [fp] [fp </> "bar"] (fp </> "bar" </> "bin") `shouldBe` False
+  prop "filtered absolute filename is not valid" $ \ (AbsoluteTest fp) -> isValid [fp] [fp </> "bar"] (fp </> "bar" </> "test.hs") `shouldBe` False
+  prop "filtered relative filename is not valid" $ \ (RelativeTest fp) -> isValid [fp] [fp </> "bar"] (fp </> "bar" </> "test.hs") `shouldBe` False
+
+  it "can find and normalize a config" $ do
+    expected :: Config <- generate arbitrary
+    (dir, actual) <- withSystemTempDirectory "simformat" $ \ dir -> do
+      writeFile (dir </> ".simformatrc") (C8.unpack $ encode expected)
+      config <- findConfig [dir </> "test.hs"]
+      pure (dir, config)
+    actual `shouldBe` normalizeConfig dir expected

--- a/test/main.hs
+++ b/test/main.hs
@@ -1,0 +1,6 @@
+import Test.Hspec (hspec)
+
+import qualified ConfigSpec
+
+main :: IO ()
+main = hspec ConfigSpec.spec


### PR DESCRIPTION
I changed a line in `app/simformat.hs` and then ran these:

* `simformat src` -> no change
* `simformat app` -> reformatted
* `simformat` -> reformatted