### PR TITLE
remove duplication between groups and non-groups

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.6
+resolver: lts-17.10
 packages:
 - .
 extra-deps: []


### PR DESCRIPTION
`import Foo (Bar(MkBar), Bar)` imports `Bar` twice. We now remove the second.