### PR TITLE
Support MagicHash

### DIFF
--- a/src/SimSpace/SimFormat.hs
+++ b/src/SimSpace/SimFormat.hs
@@ -155,7 +155,7 @@ symbolChars = some (oneOf ("!#$%&*+./<=>?@^|-~:\\" :: String)) <|> some symbolCh
 -- >>> parseMaybe symbol "(<>)"
 -- Just "(<>)"
 symbol :: Parser String
-symbol = padded $ operator <|> some (alphaNumChar <|> oneOf ("._'" :: String))
+symbol = padded $ operator <|> some (alphaNumChar <|> oneOf ("._'#" :: String))
 
 -- |
 -- >>> parseMaybe packageName "simformat"


### PR DESCRIPTION
Currently `simformat` doesn't work on files which use `MagicHash`; this adds support for it.