### PR TITLE
Sort language pragmas

### DIFF
--- a/src/SimSpace/SimFormat.hs
+++ b/src/SimSpace/SimFormat.hs
@@ -11,7 +11,7 @@ import Data.Bool (bool)
 import Data.Char (isSpace)
 import Data.Foldable (foldlM)
 import Data.Function (on)
-import Data.List (groupBy, intercalate, isInfixOf, isPrefixOf, isSuffixOf, sort)
+import Data.List (groupBy, intercalate, isInfixOf, isPrefixOf, isSuffixOf, nub, sort)
 import Data.Map (Map)
 import Data.Maybe (isJust)
 import Data.Semigroup ((<>), Semigroup)
@@ -403,7 +403,7 @@ reformat regroup programLines = do
   where
     sortLanguagePragmas :: [String] -> [String]
     sortLanguagePragmas =
-      foldMap (\xs -> if isLanguagePragma (head xs) then sort xs else xs)
+      foldMap (\xs -> if isLanguagePragma (head xs) then sort (nub xs) else xs)
         . groupBy (on (==) isLanguagePragma)
       where
       isLanguagePragma x = "{-# LANGUAGE " `isPrefixOf` x && "#-}" `isSuffixOf` x


### PR DESCRIPTION
Include a step in the format which sorts and deduplicates language pragmas of the form `{-# LANGUAGE ... #-}`. Does not attempt to sort/dedupe language pragmas which span multiple lines. If groups of language pragmas are separated by blank lines, each group is managed accordingly; neither sorting nor deduplication will occur across groups.