### PR TITLE
Removed usages of deprecated functions `decodeString` and `encodeString`

### DIFF
--- a/app/simformat.hs
+++ b/app/simformat.hs
@@ -8,7 +8,7 @@ import Data.Maybe (catMaybes)
 import Data.Traversable (for)
 import Data.Version (showVersion)
 import SimSpace.Config (Config(Config), configFiles, configWhitelist, filterFiles, findConfig)
-import Turtle (decodeString, liftIO, testfile)
+import Turtle (liftIO, testfile)
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -106,7 +106,7 @@ main = do
     format verbose allFiles Config {..} fileList regroup validate = do
       files <- filterFiles configFiles configWhitelist allFiles fileList
       inputsAndOutputs <- fmap catMaybes . for files $ \ file ->
-        liftIO (testfile $ decodeString file) >>= \ case
+        liftIO (testfile file) >>= \ case
           False -> do
             putStrLn' verbose $ "Skipping " <> file <> " because it was not in the config"
             pure Nothing


### PR DESCRIPTION
[`turtle`](https://hackage.haskell.org/package/turtle) tagged [`decodeString`](https://hackage.haskell.org/package/turtle) and [`encodeString`](https://hackage.haskell.org/package/turtle-1.6.1/docs/Turtle.html#v:encodeString) as **deprecated** in version 1.6.1 (the latest version). When building simformat from scratch, this results in an error due to the combination of `-Wdeprecations` and `-Werror`:
```
src/SimSpace/Config.hs:49:34: error: [-Wdeprecations, -Werror=deprecations]
    In the use of ‘decodeString’
    (imported from Turtle, but defined in turtle-1.6.1:Turtle.Internal):
    Deprecated: "Use id instead"
   |
49 |           (isDirectory <$> stat (decodeString file)) >>= \ case
   |                                  ^^^^^^^^^^^^

src/SimSpace/Config.hs:90:28: error: [-Wdeprecations, -Werror=deprecations]
    In the use of ‘decodeString’
    (imported from Turtle, but defined in turtle-1.6.1:Turtle.Internal):
    Deprecated: "Use id instead"
   |
90 |   let dir = commonPrefix $ decodeString <$> files
   |                            ^^^^^^^^^^^^

src/SimSpace/Config.hs:95:34: error: [-Wdeprecations, -Werror=deprecations]
    In the use of ‘encodeString’
    (imported from Turtle, but defined in turtle-1.6.1:Turtle.Internal):
    Deprecated: "Use id instead"
   |
95 |           let thisDir = mconcat (encodeString <$> x)
   |                                  ^^^^^^^^^^^^
cabal: Failed to build simformat-0.1.1.0 (which is required by exe:simformat
from simformat-0.1.1.0).
```
This PR removes the usages of the two deprecated functions. The `turtle` documentation mentions replacing with the `id` function, but I find that unnecessary when you can just remove them.