### PR TITLE
Bump resolver, build with ghc-9.6.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work/
 stack.yaml.lock
 dist-newstyle/
+.ghc.environment.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work/
 stack.yaml.lock
+dist-newstyle/

--- a/app/simformat.hs
+++ b/app/simformat.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 {-| Description: Source code for the `simformat` script, which will format and validate imports for Haskell source files. -}
 module Main (main) where
 
@@ -8,7 +10,11 @@ import Data.Maybe (catMaybes)
 import Data.Traversable (for)
 import Data.Version (showVersion)
 import SimSpace.Config (Config(Config), configFiles, configWhitelist, filterFiles, findConfig)
+#if MIN_VERSION_turtle(1,6,0)
+import Turtle (liftIO, testfile)
+#else
 import Turtle (decodeString, liftIO, testfile)
+#endif
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -106,7 +112,11 @@ main = do
     format verbose allFiles Config {..} fileList regroup validate = do
       files <- filterFiles configFiles configWhitelist allFiles fileList
       inputsAndOutputs <- fmap catMaybes . for files $ \ file ->
+#if MIN_VERSION_turtle(1,6,0)
+        liftIO (testfile file) >>= \ case
+#else
         liftIO (testfile $ decodeString file) >>= \ case
+#endif
           False -> do
             putStrLn' verbose $ "Skipping " <> file <> " because it was not in the config"
             pure Nothing

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+write-ghc-environment-files: always

--- a/package.yaml
+++ b/package.yaml
@@ -10,7 +10,7 @@ github: Simspace/simformat
 ghc-options:
 - -Wall
 - -Werror
-- -fwarn-tabs
+- -Wtabs
 - -O2
 
 default-extensions:

--- a/simformat.cabal
+++ b/simformat.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 921c5a639210d52120dc1ed6088042d9409726d44eb93ff47c8c6b2d6d84b070
+-- hash: 1dfa2675bba4e523edf025ea2ce51eccc2ccdcf728d29ba7c2097bb8a79078e5
 
 name:           simformat
 version:        0.1.1.0
@@ -35,7 +35,7 @@ library
       OverloadedStrings
       ScopedTypeVariables
       TupleSections
-  ghc-options: -Wall -Werror -fwarn-tabs -O2
+  ghc-options: -Wall -Werror -Wtabs -O2
   build-depends:
       base
     , bytestring
@@ -62,7 +62,7 @@ executable simformat
       OverloadedStrings
       ScopedTypeVariables
       TupleSections
-  ghc-options: -Wall -Werror -fwarn-tabs -O2
+  ghc-options: -Wall -Werror -Wtabs -O2
   build-depends:
       base
     , bytestring
@@ -89,7 +89,7 @@ test-suite simformat-doctests
       OverloadedStrings
       ScopedTypeVariables
       TupleSections
-  ghc-options: -Wall -Werror -fwarn-tabs -O2
+  ghc-options: -Wall -Werror -Wtabs -O2
   build-depends:
       base
     , bytestring
@@ -119,7 +119,7 @@ test-suite test
       OverloadedStrings
       ScopedTypeVariables
       TupleSections
-  ghc-options: -Wall -Werror -fwarn-tabs -O2
+  ghc-options: -Wall -Werror -Wtabs -O2
   build-depends:
       QuickCheck
     , base

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-20.20
+resolver: lts-21.0
 packages:
 - .

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,3 @@
-resolver: lts-18.10
+resolver: lts-20.20
 packages:
 - .
-extra-deps: []
-flags: {}
-extra-package-dbs: []


### PR DESCRIPTION
Built and tested with `ghc-9.6.2`, `ghc-9.4.5`, `ghc-9.2.8` and `ghc-8.10.7`.

```
$ cabal build all --enable-tests --enable-benchmarks --ghc-option=-Werror
$ cabal test all --test-show-details=always --test-option=--color
Resolving dependencies...
Build profile: -w ghc-9.6.2 -O1
...
Config
  absolute filename is always valid [✔]
    +++ OK, passed 100 tests.
  relative filename is always valid [✔]
    +++ OK, passed 100 tests.
  filtered absolute directory is not valid [✔]
    +++ OK, passed 100 tests.
  filtered relative directory is not valid [✔]
    +++ OK, passed 100 tests.
  filtered absolute filename is not valid [✔]
    +++ OK, passed 100 tests.
  filtered relative filename is not valid [✔]
    +++ OK, passed 100 tests.
  can find and normalize a config [✔]

Finished in 0.0245 seconds
7 examples, 0 failures

Test suite test: PASS
...
1 of 1 test suites (1 of 1 test cases) passed.
```